### PR TITLE
added native password authentication for mysql db connection

### DIFF
--- a/connector/mysql.go
+++ b/connector/mysql.go
@@ -17,7 +17,7 @@ const (
 	MySqlConfigKey = "mysql"
 )
 
-func GetMySqlConn(mySQLDbConfigs map[string]string, configKey string) *gorm.DB {
+func GetMySqlConn(mySQLDbConfigs map[string]string) *gorm.DB {
 	logger.GetLoggerV3().Info("initiating db connection")
 	var err error
 	connStr := formatConnString(mySQLDbConfigs)

--- a/connector/mysql.go
+++ b/connector/mysql.go
@@ -39,13 +39,14 @@ func GetMySqlConn(mySQLDbConfigs map[string]string, configKey string) *gorm.DB {
 
 func formatConnString(mySQLDbConfigs map[string]string) string {
 	config := mysql.Config{
-		User:      mySQLDbConfigs["user"],
-		Passwd:    mySQLDbConfigs["password"],
-		Net:       "tcp",
-		Addr:      mySQLDbConfigs["host"],
-		DBName:    mySQLDbConfigs["dbname"],
-		ParseTime: true,
-		Loc:       time.UTC,
+		User:                 mySQLDbConfigs["user"],
+		Passwd:               mySQLDbConfigs["password"],
+		Net:                  "tcp",
+		Addr:                 mySQLDbConfigs["host"],
+		DBName:               mySQLDbConfigs["dbname"],
+		ParseTime:            true,
+		AllowNativePasswords: true,
+		Loc:                  time.UTC,
 	}
 	return config.FormatDSN()
 }


### PR DESCRIPTION
From MySQL 8.0, caching_sha2_password authentication has become default.But since we are using native password authentication to connect to the database, AllowNativePasswords should be set as true to be able to connect to the database